### PR TITLE
chore: opensource cleanup — CI workflow, community files, gitignore

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Something isn't working as expected
+---
+
+**redux-vue version:**
+**Vue version:**
+
+**Describe the bug**
+A clear description of what the bug is.
+
+**Minimal reproduction**
+```js
+// paste snippet or link to repo
+```
+
+**Expected behaviour**
+
+**Actual behaviour**
+
+**Additional context**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,12 @@
+---
+name: Feature request
+about: Propose a new feature or improvement
+---
+
+**What problem does this solve?**
+
+**Proposed solution**
+
+**Alternatives considered**
+
+**Additional context**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- What does this PR do? -->
+
+## Related issue
+
+Closes #
+
+## Checklist
+
+- [ ] Tests written first (RED), then implementation (GREEN)
+- [ ] All tests pass (`npm test`)
+- [ ] README updated if API changed
+- [ ] Commit messages follow `fix:`/`feat:`/`docs:` convention

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,29 @@
+# Credentials & Secrets
+.env*
+*.key
+*.pem
+
 # Common
 .idea
 .DS_Store
+Thumbs.db
 
 # Logs
 logs
 *.log
+npm-debug.log
 
 # Dependency directory
 node_modules
 bower_components
 
-# Debug log from npm
-npm-debug.log
+# Build & Output
+lib
+dist/
+build/
+out/
+coverage/
+.nyc_output/
 
 # Vim
 [._]*.s[a-w][a-z]
@@ -20,5 +32,3 @@ npm-debug.log
 Session.vim
 .netrwhist
 *~
-
-lib

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,26 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity, level of experience, nationality, personal appearance, race, religion, or sexual identity.
+
+## Our Standards
+
+Positive behaviour includes:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+
+Unacceptable behaviour includes:
+- Harassment, trolling, or personal attacks
+- Publishing others' private information without permission
+- Other conduct which could reasonably be considered inappropriate
+
+## Enforcement
+
+Project maintainers may remove, edit, or reject comments, commits, code, issues, and other contributions not aligned with this Code of Conduct.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to redux-vue
+
+Thanks for taking the time to contribute!
+
+## Setup
+
+```bash
+git clone https://github.com/nadimtuhin/redux-vue.git
+cd redux-vue
+npm install
+npm test
+```
+
+## Development Workflow
+
+1. Fork the repo and create a branch: `git checkout -b fix/my-fix`
+2. Write a failing test first (TDD — see `src/connect.spec.js` for examples)
+3. Implement the fix / feature
+4. Ensure all tests pass: `npm test`
+5. Submit a pull request against `master`
+
+## Pull Request Guidelines
+
+- One concern per PR
+- Include tests for any behaviour change
+- Update README if you add a new API argument
+- Keep commits conventional: `fix:`, `feat:`, `docs:`, `test:`
+
+## Reporting Bugs
+
+Use the GitHub issue tracker. Include:
+- redux-vue version
+- Vue version
+- Minimal reproduction (snippet or repo link)
+- Expected vs actual behaviour


### PR DESCRIPTION
Prepares the repo for public consumption per opensource-cleanup checklist.

## Changes

- `.github/workflows/ci.yml` — runs `npm test` on Node 18 + 20 for every push/PR
- `.github/ISSUE_TEMPLATE/bug_report.md` + `feature_request.md`
- `.github/pull_request_template.md` — TDD checklist for contributors
- `CONTRIBUTING.md` — setup, workflow, PR guidelines
- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1
- `.gitignore` — added `.env*`, `dist/`, `coverage/`, `.nyc_output/`, `Thumbs.db`

## Checklist
- [x] No secrets in history (git log -p scan clean)
- [x] No internal URLs or IPs
- [x] LICENSE already present (MIT)
- [x] README already updated (API docs in #9)
- [x] 7/7 tests passing